### PR TITLE
Use UUIDs in ServerSurface and don't keep player instance references

### DIFF
--- a/src/main/java/com/bymarcin/openglasses/network/packet/BlockInteractPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/BlockInteractPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -11,11 +12,11 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class BlockInteractPacket extends Packet<BlockInteractPacket, IMessage> {
 
-    String player;
+    private UUID playerUUID;
     private int x, y, z, side;
 
     public BlockInteractPacket(EntityPlayer player, int x, int y, int z, int side) {
-        this.player = player.getGameProfile().getName();
+        this.playerUUID = player.getGameProfile().getId();
         this.x = x;
         this.y = y;
         this.z = z;
@@ -26,7 +27,7 @@ public class BlockInteractPacket extends Packet<BlockInteractPacket, IMessage> {
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
+        this.playerUUID = new UUID(readLong(), readLong());
         this.x = readInt();
         this.y = readInt();
         this.z = readInt();
@@ -35,7 +36,8 @@ public class BlockInteractPacket extends Packet<BlockInteractPacket, IMessage> {
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
         writeInt(x);
         writeInt(y);
         writeInt(z);
@@ -49,7 +51,7 @@ public class BlockInteractPacket extends Packet<BlockInteractPacket, IMessage> {
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.playerBlockInteract(player, x, y, z, side);
+        ServerSurface.instance.playerBlockInteract(playerUUID, x, y, z, side);
         return null;
     }
 

--- a/src/main/java/com/bymarcin/openglasses/network/packet/CloseOverlayPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/CloseOverlayPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -11,22 +12,23 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class CloseOverlayPacket extends Packet<CloseOverlayPacket, IMessage> {
 
-    String player;
+    private UUID playerUUID;
 
     public CloseOverlayPacket(EntityPlayer player) {
-        this.player = player.getGameProfile().getName();
+        this.playerUUID = player.getGameProfile().getId();
     }
 
     public CloseOverlayPacket() {}
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
+        this.playerUUID = new UUID(readLong(), readLong());
     }
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
     }
 
     @Override
@@ -36,7 +38,7 @@ public class CloseOverlayPacket extends Packet<CloseOverlayPacket, IMessage> {
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.overlayClosed(player);
+        ServerSurface.instance.overlayClosed(playerUUID);
         return null;
     }
 

--- a/src/main/java/com/bymarcin/openglasses/network/packet/EquipGlassesPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/EquipGlassesPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -12,14 +13,14 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class EquipGlassesPacket extends Packet<EquipGlassesPacket, IMessage> {
 
-    Location UUID;
-    String player;
+    private Location locationUUID;
+    private UUID playerUUID;
 
     private int width, height;
 
-    public EquipGlassesPacket(Location UUID, EntityPlayer player, int width, int height) {
-        this.player = player.getGameProfile().getName();
-        this.UUID = UUID;
+    public EquipGlassesPacket(Location locationUUID, EntityPlayer player, int width, int height) {
+        this.playerUUID = player.getGameProfile().getId();
+        this.locationUUID = locationUUID;
         this.width = width;
         this.height = height;
     }
@@ -28,20 +29,21 @@ public class EquipGlassesPacket extends Packet<EquipGlassesPacket, IMessage> {
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
-        this.UUID = new Location(readInt(), readInt(), readInt(), readInt(), readLong());
+        this.playerUUID = new UUID(readLong(), readLong());
+        this.locationUUID = new Location(readInt(), readInt(), readInt(), readInt(), readLong());
         this.width = readInt();
         this.height = readInt();
     }
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
-        writeInt(UUID.x);
-        writeInt(UUID.y);
-        writeInt(UUID.z);
-        writeInt(UUID.dimID);
-        writeLong(UUID.uniqueKey);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
+        writeInt(locationUUID.x);
+        writeInt(locationUUID.y);
+        writeInt(locationUUID.z);
+        writeInt(locationUUID.dimID);
+        writeLong(locationUUID.uniqueKey);
         writeInt(width);
         writeInt(height);
     }
@@ -53,7 +55,7 @@ public class EquipGlassesPacket extends Packet<EquipGlassesPacket, IMessage> {
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.subscribePlayer(player, UUID, width, height);
+        ServerSurface.instance.subscribePlayer(playerUUID, locationUUID, width, height);
         return null;
     }
 

--- a/src/main/java/com/bymarcin/openglasses/network/packet/InteractOverlayPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/InteractOverlayPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -11,12 +12,12 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class InteractOverlayPacket extends Packet<InteractOverlayPacket, IMessage> {
 
-    String player;
+    private UUID playerUUID;
 
     private int x, y, button, type;
 
     public InteractOverlayPacket(EntityPlayer player, int x, int y, int button, int type) {
-        this.player = player.getGameProfile().getName();
+        this.playerUUID = player.getGameProfile().getId();
         this.x = x;
         this.y = y;
         this.button = button;
@@ -28,7 +29,7 @@ public class InteractOverlayPacket extends Packet<InteractOverlayPacket, IMessag
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
+        this.playerUUID = new UUID(readLong(), readLong());
         this.x = readInt();
         this.y = readInt();
         this.button = readInt();
@@ -37,7 +38,8 @@ public class InteractOverlayPacket extends Packet<InteractOverlayPacket, IMessag
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
         writeInt(x);
         writeInt(y);
         writeInt(button);
@@ -51,7 +53,7 @@ public class InteractOverlayPacket extends Packet<InteractOverlayPacket, IMessag
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.playerHudInteract(player, x, y, button, type);
+        ServerSurface.instance.playerHudInteract(playerUUID, x, y, button, type);
         return null;
     }
 

--- a/src/main/java/com/bymarcin/openglasses/network/packet/KeyboardInteractOverlayPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/KeyboardInteractOverlayPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -11,13 +12,13 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class KeyboardInteractOverlayPacket extends Packet<KeyboardInteractOverlayPacket, IMessage> {
 
-    String player;
+    private UUID playerUUID;
 
     private int key;
     private char character;
 
     public KeyboardInteractOverlayPacket(EntityPlayer player, char character, int key) {
-        this.player = player.getGameProfile().getName();
+        this.playerUUID = player.getGameProfile().getId();
         this.character = character;
         this.key = key;
     }
@@ -26,14 +27,15 @@ public class KeyboardInteractOverlayPacket extends Packet<KeyboardInteractOverla
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
+        this.playerUUID = new UUID(readLong(), readLong());
         this.key = readInt();
         this.character = (char) readInt();
     }
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
         writeInt(key);
         writeInt(character);
     }
@@ -45,7 +47,7 @@ public class KeyboardInteractOverlayPacket extends Packet<KeyboardInteractOverla
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.playerHudKeyboardInteract(player, character, key);
+        ServerSurface.instance.playerHudKeyboardInteract(playerUUID, character, key);
         return null;
     }
 }

--- a/src/main/java/com/bymarcin/openglasses/network/packet/OpenOverlayPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/OpenOverlayPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -11,22 +12,23 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class OpenOverlayPacket extends Packet<OpenOverlayPacket, IMessage> {
 
-    String player;
+    private UUID playerUUID;
 
     public OpenOverlayPacket(EntityPlayer player) {
-        this.player = player.getGameProfile().getName();
+        this.playerUUID = player.getGameProfile().getId();
     }
 
     public OpenOverlayPacket() {}
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
+        this.playerUUID = new UUID(readLong(), readLong());
     }
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
     }
 
     @Override
@@ -36,7 +38,7 @@ public class OpenOverlayPacket extends Packet<OpenOverlayPacket, IMessage> {
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.overlayOpened(player);
+        ServerSurface.instance.overlayOpened(playerUUID);
         return null;
     }
 

--- a/src/main/java/com/bymarcin/openglasses/network/packet/UnequipGlassesPacket.java
+++ b/src/main/java/com/bymarcin/openglasses/network/packet/UnequipGlassesPacket.java
@@ -1,6 +1,7 @@
 package com.bymarcin.openglasses.network.packet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 
@@ -11,22 +12,23 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
 public class UnequipGlassesPacket extends Packet<UnequipGlassesPacket, IMessage> {
 
-    String player;
+    private UUID playerUUID;
 
     public UnequipGlassesPacket(EntityPlayer player) {
-        this.player = player.getGameProfile().getName();
+        this.playerUUID = player.getGameProfile().getId();
     }
 
     public UnequipGlassesPacket() {}
 
     @Override
     protected void read() throws IOException {
-        this.player = readString();
+        this.playerUUID = new UUID(readLong(), readLong());
     }
 
     @Override
     protected void write() throws IOException {
-        writeString(player);
+        writeLong(playerUUID.getMostSignificantBits());
+        writeLong(playerUUID.getLeastSignificantBits());
     }
 
     @Override
@@ -36,7 +38,7 @@ public class UnequipGlassesPacket extends Packet<UnequipGlassesPacket, IMessage>
 
     @Override
     protected IMessage executeOnServer() {
-        ServerSurface.instance.unsubscribePlayer(player);
+        ServerSurface.instance.unsubscribePlayer(playerUUID);
         return null;
     }
 

--- a/src/main/java/com/bymarcin/openglasses/tileentity/OpenGlassesTerminalTileEntity.java
+++ b/src/main/java/com/bymarcin/openglasses/tileentity/OpenGlassesTerminalTileEntity.java
@@ -122,7 +122,7 @@ public class OpenGlassesTerminalTileEntity extends TileEntityEnvironment {
     @Callback(direct = true)
     @Optional.Method(modid = "OpenComputers")
     public Object[] getBindPlayers(Context context, Arguments args) {
-        return ServerSurface.instance.getActivePlayers(getTerminalUUID());
+        return ServerSurface.instance.getActivePlayerNames(getTerminalUUID());
     }
     //
     // @Callback
@@ -157,8 +157,8 @@ public class OpenGlassesTerminalTileEntity extends TileEntityEnvironment {
     @Callback(direct = true)
     @Optional.Method(modid = "OpenComputers")
     public Object[] newUniqueKey(Context context, Arguments args) {
-        String[] players = ServerSurface.instance.getActivePlayers(loc);
-        for (String p : players) {
+        UUID[] players = ServerSurface.instance.getActivePlayers(loc);
+        for (UUID p : players) {
             ServerSurface.instance.sendToUUID(new WidgetUpdatePacket(), loc);
             ServerSurface.instance.unsubscribePlayer(p);
         }


### PR DESCRIPTION
I originally made this to fix a memory leak where all player instances of players that wear glasses were kept indefinitely in the `players` Map. This caused them to still receive packets, causing their `NetworkManager#outboundPacketsQueue` to grow huge, without being cleared.
While at it, I migrated `ServerSurface` to use UUIDs instead of player names everywhere.